### PR TITLE
Fix error in timbre transfer demo

### DIFF
--- a/ddsp/colab/demos/timbre_transfer.ipynb
+++ b/ddsp/colab/demos/timbre_transfer.ipynb
@@ -154,7 +154,7 @@
         "  # Load audio sample here (.mp3 or .wav3 file)\n",
         "  # Just use the first file.\n",
         "  filenames, audios = upload()\n",
-        "  audio = audios[0:1].astype(np.float32)\n",
+        "  audio = np.asarray(audios[0:1], dtype=np.float32)\n",
         "print('\\nExtracting audio features...')\n",
         "\n",
         "# Plot.\n",


### PR DESCRIPTION
I was getting an error here because `audios` was a list and not a NumPy array.

Fixes #15