### PR TITLE
Fix broken link to DDSP Timbre Transfer Colab

### DIFF
--- a/ddsp/colab/demos/train_autoencoder.ipynb
+++ b/ddsp/colab/demos/train_autoencoder.ipynb
@@ -492,7 +492,7 @@
       "source": [
         "## Download Checkpoint\n",
         "\n",
-        "Below you can download the final checkpoint. You are now ready to use it in the [DDSP Timbre Tranfer Colab](TODO)."
+        "Below you can download the final checkpoint. You are now ready to use it in the [DDSP Timbre Tranfer Colab](https://colab.research.google.com/github/magenta/ddsp/blob/master/ddsp/colab/demos/timbre_transfer.ipynb)."
       ]
     },
     {


### PR DESCRIPTION
now it links to actual notebook