### PR TITLE
Add download from gstorage and cluster_config flag

### DIFF
--- a/ddsp/training/cloud.py
+++ b/ddsp/training/cloud.py
@@ -1,0 +1,77 @@
+# Copyright 2020 The DDSP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Library of functions for training on Google Cloud AI-Platform."""
+
+import os
+import re
+
+from absl import logging
+from google.cloud import storage
+
+def download_from_gstorage(gstorage_path, local_path):
+  """Downloads a file from the bucket.
+
+  Args:
+    gstorage_path: Path to the file inside the bucket that needs to be
+      downloaded. Format: gs://bucket-name/path/to/file.txt
+    local_path: Local path where downloaded file should be stored.
+  """
+  gstorage_path = gstorage_path.strip('gs:/')
+  bucket_name = gstorage_path.split('/')[0]
+  blob_name = os.path.relpath(gstorage_path, bucket_name)
+
+  storage_client = storage.Client()
+
+  bucket = storage_client.bucket(bucket_name)
+  blob = bucket.blob(blob_name)
+
+  blob.download_to_filename(local_path)
+  logging.info(
+      'Downloaded file. Source: %s, Destination: %s',
+      gstorage_path, local_path)
+
+def make_file_paths_local(paths, local_directory):
+  """Makes sure that given files are locally available.
+
+  If Cloud Storage path is provided calls a function which downloads
+  the file and returns its new path relative to local_directory.
+  If local path is provided it is returend with no modification.
+
+  Args:
+    paths: Single path or a list of paths.
+    new_location_path: Local path to the place were downloaded files
+      will be stored. Note that if you want to download gin configuration files
+
+  Returns:
+    Single local path or a list of local paths.
+  """
+  if isinstance(paths, str):
+    if re.match('gs://*', paths):
+      local_name = os.path.basename(paths)
+      download_from_gstorage(paths, os.path.join(local_directory, local_name))
+      return local_name
+    else:
+      return paths
+  else:
+    local_paths = []
+    for path in paths:
+      if re.match('gs://*', path):
+        local_name = os.path.basename(path)
+        download_from_gstorage(path, os.path.join(local_directory, local_name))
+        local_paths.append(local_name)
+      else:
+        local_paths.append(path)
+    return local_paths

--- a/ddsp/training/ddsp_run.py
+++ b/ddsp/training/ddsp_run.py
@@ -60,18 +60,17 @@ ddsp_run \
 """
 
 import os
-import re
 import time
 
 from absl import app
 from absl import flags
 from absl import logging
+from ddsp.training import cloud
 from ddsp.training import eval_util
 from ddsp.training import models
 from ddsp.training import train_util
 from ddsp.training import trainers
 import gin
-from google.cloud import storage
 import pkg_resources
 import tensorflow.compat.v2 as tf
 
@@ -88,9 +87,9 @@ flags.DEFINE_string('restore_dir', '',
                     'Path from which checkpoints will be restored before '
                     'training. Can be different than the save_dir.')
 flags.DEFINE_string('tpu', '', 'Address of the TPU. No TPU if left blank.')
-flags.DEFINE_string('cluster_config', '', 'Worker-specific JSON string for'
-                    'multiworker setup. For more information check'
-                    'train_util.get_strategy() docstring.')
+flags.DEFINE_string('cluster_config', '',
+                    'Worker-specific JSON string for multiworker setup. '
+                    'For more information check train_util.get_strategy().')
 flags.DEFINE_boolean('allow_memory_growth', False,
                      'Whether to grow the GPU memory usage as is needed by the '
                      'process. Prevents crashes on GPUs with smaller memory.')
@@ -98,9 +97,10 @@ flags.DEFINE_boolean('allow_memory_growth', False,
 # Gin config flags.
 flags.DEFINE_multi_string('gin_search_path', [],
                           'Additional gin file search paths.')
-flags.DEFINE_multi_string('gin_file', [], 'List of paths to the config files.'
-                          'If file in gstorage bucket specify whole gstorage'
-                          'path: gs://bucket-name/dir/in/bucket/file.gin.')
+flags.DEFINE_multi_string('gin_file', [],
+                          'List of paths to the config files. If file '
+                          'in gstorage bucket specify whole gstorage path: '
+                          'gs://bucket-name/dir/in/bucket/file.gin.')
 flags.DEFINE_multi_string('gin_param', [],
                           'Newline separated list of Gin parameter bindings.')
 
@@ -119,59 +119,6 @@ def delay_start():
     logging.info('Waiting for %i second(s)', delay_time)
     time.sleep(delay_time)
 
-def download_from_gstorage(gstorage_path, local_path):
-  """Downloads the bucket.
-
-  Args:
-    gstorage_path: Path to the object inside the bucket that needs to be
-      downloaded. Format: gs://bucket-name/path/to/file.txt
-    local_path: Local path where downloaded file should be stored.
-  """
-  gstorage_path = gstorage_path.strip('gs:/')
-  bucket_name = gstorage_path.split('/')[0]
-  blob_name = os.path.relpath(gstorage_path, bucket_name)
-
-  storage_client = storage.Client()
-
-  bucket = storage_client.bucket(bucket_name)
-  blob = bucket.blob(blob_name)
-
-  blob.download_to_filename(local_path)
-  logging.info(
-      'Downloaded the bucket object %s. Current location: %s',
-      gstorage_path, local_path)
-
-def handle_gstorage_paths(paths):
-  """Handles gstorage paths.
-
-  If gstorage path is provided calls a function which downloads the file.
-  If local path is provided nothing happens.
-
-  Args:
-    paths: Single path or a list of paths.
-
-  Returns:
-    Single local path or a list of local paths.
-  """
-  if isinstance(paths, str):
-    if re.match('gs://*', paths):
-      local_name = os.path.basename(paths)
-      download_from_gstorage(paths, os.path.join(GIN_PATH, local_name))
-      return local_name
-    else:
-      return paths
-  else:
-    local_paths = []
-    for path in paths:
-      if re.match('gs://*', path):
-        local_name = os.path.basename(path)
-        download_from_gstorage(path, os.path.join(GIN_PATH, local_name))
-        local_paths.append(local_name)
-      else:
-        local_paths.append(path)
-    return local_paths
-
-
 def parse_gin(restore_dir):
   """Parse gin config from --gin_file, --gin_param, and the model directory."""
   # Add user folders to the gin search path.
@@ -189,14 +136,13 @@ def parse_gin(restore_dir):
     operative_config = train_util.get_latest_operative_config(restore_dir)
     if tf.io.gfile.exists(operative_config):
       logging.info('Using operative config: %s', operative_config)
-      operative_config = handle_gstorage_paths(operative_config)
+      operative_config = cloud.make_file_paths_local(operative_config, GIN_PATH)
       gin.parse_config_file(operative_config, skip_unknown=True)
 
     # User gin config and user hyperparameters from flags.
-    gin_file = handle_gstorage_paths(FLAGS.gin_file)
+    gin_file = cloud.make_file_paths_local(FLAGS.gin_file, GIN_PATH)
     gin.parse_config_files_and_bindings(
         gin_file, FLAGS.gin_param, skip_unknown=True)
-
 
 def allow_memory_growth():
   """Sets the GPUs to grow the memory usage as is needed by the process."""

--- a/ddsp/training/ddsp_run.py
+++ b/ddsp/training/ddsp_run.py
@@ -96,6 +96,10 @@ flags.DEFINE_boolean('allow_memory_growth', False,
 flags.DEFINE_boolean('hypertune', False,
                      'Enable metric reporting for hyperparameter tuning, such '
                      'as on Google Cloud AI-Platform.')
+flags.DEFINE_float('early_stop_loss_value', None,
+                   'Early stopping. When the total_loss reaches below this '
+                   'value training stops. If None training will run for '
+                   'num_steps steps.')
 
 # Gin config flags.
 flags.DEFINE_multi_string('gin_search_path', [],
@@ -188,7 +192,8 @@ def main(unused_argv):
                      trainer=trainer,
                      save_dir=save_dir,
                      restore_dir=restore_dir,
-                     report_loss_to_hypertune=FLAGS.hypertune)
+                     report_loss_to_hypertune=FLAGS.hypertune,
+                     early_stop_loss_value=FLAGS.early_stop_loss_value)
 
   # Evaluation.
   elif FLAGS.mode == 'eval':

--- a/ddsp/training/ddsp_run.py
+++ b/ddsp/training/ddsp_run.py
@@ -60,6 +60,7 @@ ddsp_run \
 """
 
 import os
+import re
 import time
 
 from absl import app
@@ -70,6 +71,7 @@ from ddsp.training import models
 from ddsp.training import train_util
 from ddsp.training import trainers
 import gin
+from google.cloud import storage
 import pkg_resources
 import tensorflow.compat.v2 as tf
 
@@ -86,6 +88,9 @@ flags.DEFINE_string('restore_dir', '',
                     'Path from which checkpoints will be restored before '
                     'training. Can be different than the save_dir.')
 flags.DEFINE_string('tpu', '', 'Address of the TPU. No TPU if left blank.')
+flags.DEFINE_string('cluster_config', '', 'Worker-specific JSON string for'
+                    'multiworker setup. For more information check'
+                    'train_util.get_strategy() docstring.')
 flags.DEFINE_boolean('allow_memory_growth', False,
                      'Whether to grow the GPU memory usage as is needed by the '
                      'process. Prevents crashes on GPUs with smaller memory.')
@@ -93,7 +98,9 @@ flags.DEFINE_boolean('allow_memory_growth', False,
 # Gin config flags.
 flags.DEFINE_multi_string('gin_search_path', [],
                           'Additional gin file search paths.')
-flags.DEFINE_multi_string('gin_file', [], 'List of paths to the config files.')
+flags.DEFINE_multi_string('gin_file', [], 'List of paths to the config files.'
+                          'If file in gstorage bucket specify whole gstorage'
+                          'path: gs://bucket-name/dir/in/bucket/file.gin.')
 flags.DEFINE_multi_string('gin_param', [],
                           'Newline separated list of Gin parameter bindings.')
 
@@ -111,6 +118,58 @@ def delay_start():
   if delay_time:
     logging.info('Waiting for %i second(s)', delay_time)
     time.sleep(delay_time)
+
+def download_from_gstorage(gstorage_path, local_path):
+  """Downloads the bucket.
+
+  Args:
+    gstorage_path: Path to the object inside the bucket that needs to be
+      downloaded. Format: gs://bucket-name/path/to/file.txt
+    local_path: Local path where downloaded file should be stored.
+  """
+  gstorage_path = gstorage_path.strip('gs:/')
+  bucket_name = gstorage_path.split('/')[0]
+  blob_name = os.path.relpath(gstorage_path, bucket_name)
+
+  storage_client = storage.Client()
+
+  bucket = storage_client.bucket(bucket_name)
+  blob = bucket.blob(blob_name)
+
+  blob.download_to_filename(local_path)
+  logging.info(
+      'Downloaded the bucket object %s. Current location: %s',
+      gstorage_path, local_path)
+
+def handle_gstorage_paths(paths):
+  """Handles gstorage paths.
+
+  If gstorage path is provided calls a function which downloads the file.
+  If local path is provided nothing happens.
+
+  Args:
+    paths: Single path or a list of paths.
+
+  Returns:
+    Single local path or a list of local paths.
+  """
+  if isinstance(paths, str):
+    if re.match('gs://*', paths):
+      local_name = os.path.basename(paths)
+      download_from_gstorage(paths, os.path.join(GIN_PATH, local_name))
+      return local_name
+    else:
+      return paths
+  else:
+    local_paths = []
+    for path in paths:
+      if re.match('gs://*', path):
+        local_name = os.path.basename(path)
+        download_from_gstorage(path, os.path.join(GIN_PATH, local_name))
+        local_paths.append(local_name)
+      else:
+        local_paths.append(path)
+    return local_paths
 
 
 def parse_gin(restore_dir):
@@ -130,11 +189,13 @@ def parse_gin(restore_dir):
     operative_config = train_util.get_latest_operative_config(restore_dir)
     if tf.io.gfile.exists(operative_config):
       logging.info('Using operative config: %s', operative_config)
+      operative_config = handle_gstorage_paths(operative_config)
       gin.parse_config_file(operative_config, skip_unknown=True)
 
     # User gin config and user hyperparameters from flags.
+    gin_file = handle_gstorage_paths(FLAGS.gin_file)
     gin.parse_config_files_and_bindings(
-        FLAGS.gin_file, FLAGS.gin_param, skip_unknown=True)
+        gin_file, FLAGS.gin_param, skip_unknown=True)
 
 
 def allow_memory_growth():
@@ -167,7 +228,9 @@ def main(unused_argv):
 
   # Training.
   if FLAGS.mode == 'train':
-    strategy = train_util.get_strategy(tpu=FLAGS.tpu)
+    strategy = train_util.get_strategy(
+        tpu=FLAGS.tpu,
+        cluster_config=FLAGS.cluster_config)
     with strategy.scope():
       model = models.get_model()
       trainer = trainers.Trainer(model, strategy)

--- a/ddsp/training/ddsp_run_test.py
+++ b/ddsp/training/ddsp_run_test.py
@@ -1,0 +1,78 @@
+# Copyright 2020 The DDSP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Tests for ddsp.training.ddsp_run."""
+
+from unittest import mock
+
+import ddsp_run
+import tensorflow.compat.v2 as tf
+
+class DownloadFromGstorageTest(tf.test.TestCase):
+
+  @mock.patch('google.cloud.storage.Client.bucket')
+  def test_bucket_name(self, bucket_function):
+    """Check if proper bucket name is infered from path."""
+    ddsp_run.download_from_gstorage(
+        'gs://bucket-name/bucket/dir/some_file.gin',
+        'local/path/some_file.gin')
+    bucket_function.assert_called_with('bucket-name')
+
+
+class HandleGstoragePathsTest(tf.test.TestCase):
+
+  @mock.patch('ddsp_run.download_from_gstorage')
+  def test_single_path_handling(self, download_from_gstorage_function):
+    """Tests that function returns a single value if given single value."""
+    path = ddsp_run.handle_gstorage_paths(
+        'gs://bucket-name/bucket/dir/some_file.gin')
+    download_from_gstorage_function.assert_called_once()
+    self.assertEqual(path, 'some_file.gin')
+
+  @mock.patch('ddsp_run.download_from_gstorage')
+  def test_single_local_path_handling(self, download_from_gstorage_function):
+    """Tests that function does nothing if given local file path."""
+    path = ddsp_run.handle_gstorage_paths(
+        'local_file.gin')
+    download_from_gstorage_function.assert_not_called()
+    self.assertEqual(path, 'local_file.gin')
+
+  @mock.patch('ddsp_run.download_from_gstorage')
+  def test_single_path_in_list_handling(self, download_from_gstorage_function):
+    """Tests that function returns a single-element list if given one."""
+    path = ddsp_run.handle_gstorage_paths(
+        ['gs://bucket-name/bucket/dir/some_file.gin'])
+    download_from_gstorage_function.assert_called_once()
+    self.assertNotIsInstance(path, str)
+    self.assertListEqual(path, ['some_file.gin'])
+
+  @mock.patch('ddsp_run.download_from_gstorage')
+  def test_more_paths_in_list_handling(self, download_from_gstorage_function):
+    """Tests that function handle both local and gstorage paths in one list."""
+    paths = ddsp_run.handle_gstorage_paths(
+        ['gs://bucket-name/bucket/dir/first_file.gin',
+         'local_file.gin',
+         'gs://bucket-name/bucket/dir/second_file.gin'])
+    self.assertEqual(download_from_gstorage_function.call_count, 2)
+    download_from_gstorage_function.assert_has_calls(
+        [mock.call('gs://bucket-name/bucket/dir/first_file.gin', mock.ANY),
+         mock.call('gs://bucket-name/bucket/dir/second_file.gin', mock.ANY)])
+    self.assertListEqual(
+        paths,
+        ['first_file.gin', 'local_file.gin', 'second_file.gin'])
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/ddsp/training/train_util.py
+++ b/ddsp/training/train_util.py
@@ -67,7 +67,9 @@ def get_strategy(tpu='', cluster_config=''):
     resolver = tf.distribute.cluster_resolver.SimpleClusterResolver(
         cluster_spec=cluster_spec,
         task_type=cluster_config['task']['type'],
-        task_id=cluster_config['task']['index'])
+        task_id=cluster_config['task']['index'],
+        num_accelerators={'GPU': len(tf.config.list_physical_devices('GPU'))},
+        rpc_layer='grpc')
     strategy = tf.distribute.experimental.MultiWorkerMirroredStrategy(
         cluster_resolver=resolver)
   else:

--- a/ddsp/training/train_util.py
+++ b/ddsp/training/train_util.py
@@ -166,7 +166,7 @@ def train(data_provider,
    steps_per_summary: Number of training steps per summary save.
    steps_per_save: Number of training steps per checkpoint save.
    save_dir: Directory where checkpoints and summaries will be saved.
-     If None, no checkpoints or summaries will be saved.
+     If empty string, no checkpoints or summaries will be saved.
    restore_dir: Directory where latest checkpoints for resuming the training
      are stored. If there are no checkpoints in this directory, training will
      begin anew.
@@ -186,7 +186,7 @@ def train(data_provider,
   # Load latest checkpoint if one exists in load directory.
   trainer.restore(restore_dir)
 
-  if save_dir is not None:
+  if save_dir:
     # Set up the summary writer and metrics.
     summary_dir = os.path.join(save_dir, 'summaries', 'train')
     summary_writer = tf.summary.create_file_writer(summary_dir)
@@ -225,7 +225,7 @@ def train(data_provider,
       logging.info(log_str)
 
       # Write Summaries.
-      if step % steps_per_summary == 0 and save_dir is not None:
+      if step % steps_per_summary == 0 and save_dir:
         # Speed.
         steps_per_sec = steps_per_summary / (time.time() - tick)
         tf.summary.scalar('steps_per_sec', steps_per_sec, step=step)
@@ -247,13 +247,13 @@ def train(data_provider,
                      early_stop_loss_value)
 
         # Write a final checkpoint.
-        if save_dir is not None:
+        if save_dir:
           trainer.save(save_dir)
           summary_writer.flush()
         break
 
       # Save Model.
-      if step % steps_per_save == 0 and save_dir is not None:
+      if step % steps_per_save == 0 and save_dir:
         trainer.save(save_dir)
         summary_writer.flush()
 


### PR DESCRIPTION
Add download from gstorage and cluster_config flag

- cluster_config flag for multi-worker training.
- Downloading configuration flags from gstorage.
- Handling gstorage config paths.
- Tests for handling gstorage config paths.
- Small strategy update, I haven't set everything correctly last time.