### PR TITLE
Fix small typo in timbre_transfer demo notebook

### DIFF
--- a/ddsp/colab/demos/timbre_transfer.ipynb
+++ b/ddsp/colab/demos/timbre_transfer.ipynb
@@ -336,7 +336,7 @@
         "#@markdown Shift the pitch (octaves)\n",
         "pitch_shift =  0 #@param {type:\"slider\", min:-2, max:2, step:1}\n",
         "\n",
-        "#@markdown Adjsut the overall loudness (dB)\n",
+        "#@markdown Adjust the overall loudness (dB)\n",
         "loudness_shift = 0 #@param {type:\"slider\", min:-20, max:20, step:1}\n",
         "\n",
         "\n",

--- a/ddsp/version.py
+++ b/ddsp/version.py
@@ -19,4 +19,4 @@ Stored in a separate file so that setup.py can reference the version without
 pulling in all the dependencies in __init__.py.
 """
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'


### PR DESCRIPTION
### Notes
Fix small typo in timbre_transfer demo notebook `Adjsut` -> `Adjust`

### Testing 
* pytest
* pylint ddsp


```
 214 passed, 35 skipped, 47 warnings in 88.82s (0:01:28)
```
```
Your code has been rated at 10.00/10
```
