### PR TITLE
Fix slow data preparation

### DIFF
--- a/ddsp/training/data_preparation/prepare_tfrecord_lib.py
+++ b/ddsp/training/data_preparation/prepare_tfrecord_lib.py
@@ -69,7 +69,7 @@ def _chunk_audio(ex, sample_rate, chunk_secs):
   chunks = tf.signal.frame(audio, chunk_size, chunk_size, pad_end=True)
   n_chunks = chunks.shape[0]
   for i in range(n_chunks):
-    yield {'audio': chunks[i]}
+    yield {'audio': chunks[i].numpy()}
 
 
 def _add_f0_estimate(ex, frame_rate, center, viterbi):


### PR DESCRIPTION
Fixes #420

In my case this has brought back the data preprocessing time from ~4 hours to a few minutes.

The cause was the usage of a tf tensor in the construction of `tf.train.Example`, which is doesn't seem to like at all. I don't think the chunk was passed around as a tensor on purpose.