### PR TITLE
Remove down-pinning of numba

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setuptools.setup(
         'pydub',
         'mir_eval',
         'note_seq',
-        'numba < 0.50',  # temporary fix for librosa import
         'numpy',
         'scipy',
         'six',


### PR DESCRIPTION
I'm trying to use ddsp in conjunction with a library that requires a recent numpy version and thus a recent numba version `numba>0.51`. I don't think this 2-year old temporary work-around is still needed.

Since [numba 0.50 has added numpy 1.18 support](https://numba.readthedocs.io/en/stable/release-notes.html#version-0-50-0-jun-10-2020), pinning it below 0.50 basically means that numpy is required to be below `1.18`. This is quite old, and as far as I can see, there is no real justification for that. It is librosa's responsibility to annotate their requirement on numba, ddsp should not interfere. The requirement has changed a few times over the last 2 years, and just the last few days there has been another iterion on this, which should settle the pinning again on their side.

Would it be possible to make a patch release without that pinning?