### PR TITLE
fix the use of training a model on the colab

### DIFF
--- a/ddsp/colab/colab_utils.py
+++ b/ddsp/colab/colab_utils.py
@@ -183,7 +183,8 @@ def upload(sample_rate=DEFAULT_SAMPLE_RATE, normalize_db=None):
 def save_dataset_statistics(data_provider,
                             file_path=None,
                             batch_size=1,
-                            power_frame_size=256,):
+                            power_frame_size=256,
+                            power_frame_rate=250):
   """Calculate dataset stats and save in a pickle file.
 
   Calls out to postprocessing.compute_dataset_statistics.
@@ -201,7 +202,7 @@ def save_dataset_statistics(data_provider,
   """
 
   ds_stats = ddsp.training.postprocessing.compute_dataset_statistics(
-      data_provider, batch_size, power_frame_size)
+      data_provider, batch_size, power_frame_size, power_frame_rate)
 
   # Save.
   if file_path is not None:

--- a/ddsp/training/postprocessing.py
+++ b/ddsp/training/postprocessing.py
@@ -325,6 +325,10 @@ def compute_dataset_statistics(data_provider,
       mean_min = np.mean(np.min(x, axis=-1))
     else:
       max_list = []
+      if x.shape != note_mask.shape:
+        min_length = min(x.shape[1], note_mask.shape[1])
+        x = x[:, :min_length]
+        note_mask = note_mask[:, :min_length]
       for x_i, m in zip(x, note_mask):
         if np.sum(m) > 0:
           max_list.append(np.max(x_i[m]))


### PR DESCRIPTION
When training the model on colab, the program reported an error when saving dataset_statistic. I found in the Issue that others also encountered the same problem.. I checked the ddsp library and found that framerate was not passed as a parameter into the calculation process. When training with the default configuration in the notebook, the default value of frame_rate is 250, but for the compute_dataset_statistics function, the default value of frame_rate is 50, so I add it as a parameter in the save_dataset_statistics function and pass it to compute_dataset_statistics.

Directly pip install ddsp==3.6.0 in colab, the training will not be able to use colab's GPU, I modified the pip part to use colab's default tensorflow. I used the modified version and trained several models on colab, and the GPU can be used normally.